### PR TITLE
fix logout

### DIFF
--- a/www/social-vk.js
+++ b/www/social-vk.js
@@ -14,7 +14,7 @@ SocialVk.prototype.share = function(sourceURL, description, imageURL, successCal
 };
 
 SocialVk.prototype.logout = function(successCallback, errorCallback) {
-    cordova.exec(successCallback, errorCallback, "SocialVk", "logout");
+    cordova.exec(successCallback, errorCallback, "SocialVk", "logout", []);
 };
 
 // API methods


### PR DESCRIPTION
cordova 5.x (не пробовал другие версии) кидает исключение, если не передавать в exec() массив аргументов.
